### PR TITLE
Improve bridge action details

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
     "@rainbow-me/rainbowkit": "^2.0.6",
     "@tanstack/react-query": "^5.32.0",
     "clsx": "^2.1.1",

--- a/public/vertical-dashes.svg
+++ b/public/vertical-dashes.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="34" viewBox="0 0 24 34" fill="none">
+  <path d="M12 1L12 34" stroke="#D2D1D4" stroke-width="2" stroke-linecap="round" stroke-dasharray="0 6 1 6"
+    stroke-dashoffset="1" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
   const targetChain = bridgeMode === "deposit" ? rollupChain : parentChain;
 
   useEffect(() => {
-    setApproved(allowance >= amount);
+    setApproved(amount > 0n && allowance >= amount);
     amount === 0n
       ? setActionButtonDisabled(true)
       : setActionButtonDisabled(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { OperationSummary } from "./components/OperationSummary";
 import { ActionButton } from "./components/ActionButton";
 import { Transactions } from "./components/Transactions";
 import { Tabs } from "./components/Tabs";
+import { DepositModal } from "./components/DepositModal";
 
 type Inputs = {
   amount: bigint;
@@ -35,6 +36,7 @@ function App() {
 
   const [isApproved, setApproved] = useState(false);
   const [actionButtonDisabled, setActionButtonDisabled] = useState(false);
+  const [showDepositModal, setShowDepositModal] = useState(false);
   const [bridgeMode, setBridgeMode] = useState<BridgeMode>("deposit");
   const { transactions, addTransaction } = useTransactionStorage();
 
@@ -75,7 +77,7 @@ function App() {
     try {
       if (bridgeMode === "deposit") {
         if (isApproved) {
-          await depositFn(walletClient, submittedAmount);
+          setShowDepositModal(true);
         } else {
           await approvalFn(walletClient, submittedAmount);
         }
@@ -181,6 +183,14 @@ function App() {
       <div className="w-full lg:w-[488px] m-auto flex flex-col gap-4">
         <Transactions transactions={transactions} />
       </div>
+      <DepositModal
+        amount={amount}
+        open={showDepositModal}
+        setOpen={setShowDepositModal}
+        triggerDeposit={() => {
+          depositFn(walletClient as WalletClient, amount);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -1,12 +1,19 @@
 import { clsx } from "clsx";
 import { useEffect, useState } from "react";
 import { useWalletClient } from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 
 import { parentChain, rollupChain } from "../config";
 import { useIsParentChain } from "../hooks";
 import { BridgeMode } from "../types";
+import { WalletIcon } from "./icons";
 
-type ButtonMode = "approve" | "deposit" | "withdraw" | "network-error";
+type ButtonMode =
+  | "approve"
+  | "deposit"
+  | "withdraw"
+  | "network-error"
+  | "connect-wallet";
 
 export const ActionButton = ({
   disabled,
@@ -20,6 +27,7 @@ export const ActionButton = ({
   const isParentChain = useIsParentChain();
   const [buttonMode, setButtonMode] = useState<ButtonMode>("withdraw");
   const { data: walletClient } = useWalletClient();
+  const { openConnectModal } = useConnectModal();
 
   const chainForMode = mode === "deposit" ? parentChain : rollupChain;
 
@@ -31,7 +39,9 @@ export const ActionButton = ({
   };
 
   useEffect(() => {
-    if (
+    if (!walletClient?.account) {
+      setButtonMode("connect-wallet");
+    } else if (
       (isParentChain && mode === "withdraw") ||
       (!isParentChain && mode === "deposit")
     ) {
@@ -45,7 +55,7 @@ export const ActionButton = ({
     } else {
       setButtonMode("withdraw");
     }
-  }, [isParentChain, mode, depositApproved]);
+  }, [isParentChain, mode, depositApproved, walletClient?.account]);
 
   if (buttonMode === "network-error") {
     return (
@@ -59,6 +69,23 @@ export const ActionButton = ({
         )}
       >
         {labels[buttonMode]}
+      </button>
+    );
+  }
+
+  if (buttonMode === "connect-wallet") {
+    return (
+      <button
+        onClick={openConnectModal}
+        className={clsx(
+          "w-full rounded-[4px] py-3 px-4 text-sm",
+          "bg-accent dark:bg-accent-dark",
+          "text-accent-foreground dark:text-accent-foreground-dark",
+          "flex flex-row items-center justify-center gap-1"
+        )}
+      >
+        <WalletIcon />
+        Connect wallet
       </button>
     );
   }

--- a/src/components/DepositModal.tsx
+++ b/src/components/DepositModal.tsx
@@ -1,0 +1,75 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { CloseIcon } from "./icons";
+import { formatEther } from "viem";
+import { parentChain, rollupChain } from "../config";
+import clsx from "clsx";
+import { useEstimateDepositGas } from "../hooks";
+
+const DetailRow = ({ label, value }: { label: string; value: string }) => (
+  <div>
+    <p className="text-[#9e9ba6] text-base font-normal">{label}</p>
+    <p className="font-medium text-xl">{value}</p>
+  </div>
+);
+
+export const DepositModal = ({
+  amount,
+  open,
+  setOpen,
+  triggerDeposit,
+}: {
+  amount: bigint;
+  open: boolean;
+  setOpen: (value: boolean) => void;
+  triggerDeposit: () => void;
+}) => {
+  const { gas: gasEstimate } = useEstimateDepositGas({ amount });
+  const buttonStyle = clsx(
+    "border-accent text-accent dark:border-accent-dark dark:text-accent-dark",
+    "text-xs rounded-[4px] border w-full py-3"
+  );
+
+  const activeButtonStyle = clsx(
+    "border-accent bg-accent text-accent-foreground",
+    buttonStyle
+  );
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50" />
+      <Dialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white p-6 rounded-lg flex flex-col gap-8">
+        <div className="flex flex-row justify-between items-start">
+          <Dialog.Title className="font-semibold text-2xl">
+            Deposit
+          </Dialog.Title>
+          <Dialog.Close>
+            <CloseIcon />
+          </Dialog.Close>
+        </div>
+        <div className="w-96 flex flex-col gap-6">
+          <DetailRow label="Routing" value="Standard Speed" />
+          <DetailRow
+            label="Amount of deposit"
+            value={`${formatEther(amount)} ${
+              rollupChain.nativeCurrency.symbol
+            }`}
+          />
+          <DetailRow
+            label="Gas fee"
+            value={`${formatEther(gasEstimate)} ${
+              parentChain.nativeCurrency.symbol
+            }`}
+          />
+          <DetailRow label="Time to transfer" value="~1 minute" />
+          <div className="flex flex-row gap-2">
+            <Dialog.Close asChild>
+              <button className={buttonStyle}>Cancel</button>
+            </Dialog.Close>
+            <button className={activeButtonStyle} onClick={triggerDeposit}>
+              Deposit
+            </button>
+          </div>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};

--- a/src/components/OperationSummary.tsx
+++ b/src/components/OperationSummary.tsx
@@ -112,14 +112,17 @@ export const OperationSummary = ({
     if (!walletClient?.account) {
       return;
     }
-    getGasEstimate({
-      account: walletClient.account,
-      amount,
-      depositApproved,
-      mode,
-    }).then((estimate) => {
-      setGasEstimate(estimate);
-    });
+    const debounce = setTimeout(() => {
+      getGasEstimate({
+        account: walletClient.account,
+        amount,
+        depositApproved,
+        mode,
+      }).then((estimate) => {
+        setGasEstimate(estimate);
+      });
+    }, 100);
+    return () => clearTimeout(debounce);
   }, [walletClient, amount, mode, depositApproved]);
 
   return (

--- a/src/components/WithdrawalActions.tsx
+++ b/src/components/WithdrawalActions.tsx
@@ -12,7 +12,7 @@ import {
   useEstimateFinalizeWithdrawalGas,
 } from "../hooks";
 import { finalizeWithdrawal, proveWithdrawal } from "../txs/withdraw";
-import { ExternalLinkIcon, WithdrawalStatusIcon } from "./icons";
+import { CloseIcon, ExternalLinkIcon, WithdrawalStatusIcon } from "./icons";
 import { blockExplorerURL } from "../utils";
 
 export const WithdrawalActions = ({
@@ -68,28 +68,7 @@ export const WithdrawalActions = ({
             Withdrawal
           </Dialog.Title>
           <Dialog.Close>
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7 17L17 7"
-                stroke="#9E9BA6"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M7 7L17 17"
-                stroke="#9E9BA6"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <CloseIcon />
           </Dialog.Close>
         </div>
         <div>
@@ -103,7 +82,7 @@ export const WithdrawalActions = ({
           </div>
         </div>
         <Dialog.Description asChild>
-          <div className="w-[632px] flex flex-col gap-6">
+          <div className="w-96 flex flex-col gap-6">
             <ul className="list-image-[url(/vertical-dashes.svg)] list-inside">
               <li className="flex flex-row justify-between">
                 <div className="flex flex-row gap-1">
@@ -177,7 +156,7 @@ export const WithdrawalActions = ({
                 </button>
               )}
             </div>
-            <p className="text-[#9e9ba6] font-normal text-base text-center">
+            <p className="text-[#9e9ba6] font-normal text-sm text-center">
               You can close this window and reopen it later by clicking on the
               transaction.
             </p>

--- a/src/components/icons/Close.tsx
+++ b/src/components/icons/Close.tsx
@@ -1,0 +1,26 @@
+export const CloseIcon = () => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 17L17 7"
+        stroke="#9E9BA6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 7L17 17"
+        stroke="#9E9BA6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/components/icons/ExternalLink.tsx
+++ b/src/components/icons/ExternalLink.tsx
@@ -1,0 +1,38 @@
+export const ExternalLinkIcon = () => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g clipPath="url(#clip0_250_6919)">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M11 4.25H6C4.48122 4.25 3.25 5.48122 3.25 7V18C3.25 19.5188 4.48122 20.75 6 20.75H17C18.5188 20.75 19.75 19.5188 19.75 18V13H18.25V18C18.25 18.6904 17.6904 19.25 17 19.25H6C5.30964 19.25 4.75 18.6904 4.75 18V7C4.75 6.30964 5.30964 5.75 6 5.75H11V4.25Z"
+          fill="#8C6AE5"
+        />
+        <path
+          d="M21.6064 8.60742L21.6064 2.53635L15.5354 2.53635"
+          stroke="#8C6AE5"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M13 11.1426L20.8995 3.24312"
+          stroke="#8C6AE5"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_250_6919">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};

--- a/src/components/icons/Wallet.tsx
+++ b/src/components/icons/Wallet.tsx
@@ -1,0 +1,19 @@
+export const WalletIcon = () => {
+  return (
+    <svg
+      width="25"
+      height="24"
+      viewBox="0 0 25 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6.5 7H18.5M18.5 7H19.5C20.6046 7 21.5 7.89543 21.5 9V18C21.5 19.1046 20.6046 20 19.5 20H5.5C4.39543 20 3.5 19.1046 3.5 18V6C3.5 4.89543 4.39543 4 5.5 4H16.5C17.6046 4 18.5 4.89543 18.5 6V7Z"
+        stroke="#FEFEFE"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="17" cy="13.5" r="1.5" fill="#FEFEFE" />
+    </svg>
+  );
+};

--- a/src/components/icons/WithdrawalProgress.tsx
+++ b/src/components/icons/WithdrawalProgress.tsx
@@ -1,6 +1,7 @@
 import { TransactionReceipt } from "viem";
-import { useGetWithdrawalStatus } from "../hooks";
+import { useGetWithdrawalStatus } from "../../hooks";
 import { useEffect, useState } from "react";
+import { statusStep } from "../../utils";
 
 export const WithdrawalProgressIcon = ({
   transaction,
@@ -10,29 +11,10 @@ export const WithdrawalProgressIcon = ({
   const { status } = useGetWithdrawalStatus(transaction);
   const [segmentProgress, setSegmentProgress] = useState<number>(0);
 
-  const segmentFillColor = import.meta.env.VITE_BRIDGE_ACCENT_COLOR;
+  const accentColor = import.meta.env.VITE_BRIDGE_ACCENT_COLOR;
 
   useEffect(() => {
-    switch (status) {
-      case "retrieving-status":
-        setSegmentProgress(0);
-        break;
-      case "waiting-to-prove":
-        setSegmentProgress(1);
-        break;
-      case "ready-to-prove":
-        setSegmentProgress(2);
-        break;
-      case "waiting-to-finalize":
-        setSegmentProgress(3);
-        break;
-      case "ready-to-finalize":
-        setSegmentProgress(4);
-        break;
-      case "finalized":
-        setSegmentProgress(5);
-        break;
-    }
+    setSegmentProgress(statusStep(status));
   }, [status]);
 
   return (
@@ -47,22 +29,22 @@ export const WithdrawalProgressIcon = ({
         {/* segment one */}
         <path
           d="M26.5771 13.5195C27.3573 13.4897 27.973 12.8311 27.8647 12.0578C27.4441 9.05479 26.0568 6.2551 23.8933 4.09428C21.7297 1.93345 18.9283 0.549719 15.9247 0.132902C15.1513 0.0255755 14.4935 0.642079 14.4647 1.42235C14.4358 2.20262 15.0479 2.8494 15.8183 2.97646C18.1082 3.35413 20.2365 4.43838 21.8952 6.09491C23.5538 7.75144 24.6407 9.87845 25.0212 12.1678C25.1493 12.9381 25.7968 13.5493 26.5771 13.5195Z"
-          fill={segmentProgress >= 1 ? segmentFillColor : "#D2D1D4"}
+          fill={segmentProgress >= 1 ? accentColor : "#D2D1D4"}
         />
         {/* segment two */}
         <path
           d="M26.5771 14.4805C27.3573 14.5103 27.973 15.1689 27.8647 15.9422C27.4441 18.9452 26.0568 21.7449 23.8933 23.9057C21.7297 26.0665 18.9283 27.4503 15.9247 27.8671C15.1513 27.9744 14.4935 27.3579 14.4647 26.5777C14.4358 25.7974 15.0479 25.1506 15.8183 25.0235C18.1082 24.6459 20.2365 23.5616 21.8952 21.9051C23.5538 20.2486 24.6407 18.1216 25.0212 15.8322C25.1493 15.0619 25.7968 14.4507 26.5771 14.4805Z"
-          fill={segmentProgress >= 2 ? segmentFillColor : "#D2D1D4"}
+          fill={segmentProgress >= 2 ? accentColor : "#D2D1D4"}
         />
         {/* segment three */}
         <path
           d="M1.42294 14.4805C0.64271 14.5103 0.0270348 15.1689 0.135334 15.9422C0.555929 18.9452 1.94319 21.7449 4.10674 23.9057C6.27028 26.0665 9.07171 27.4503 12.0753 27.8671C12.8487 27.9744 13.5065 27.3579 13.5353 26.5777C13.5642 25.7974 12.9521 25.1506 12.1817 25.0235C9.89184 24.6459 7.76346 23.5616 6.10485 21.9051C4.44623 20.2486 3.35931 18.1216 2.97876 15.8322C2.85072 15.0619 2.20318 14.4507 1.42294 14.4805Z"
-          fill={segmentProgress >= 3 ? segmentFillColor : "#D2D1D4"}
+          fill={segmentProgress >= 3 ? accentColor : "#D2D1D4"}
         />
         {/* segment four */}
         <path
           d="M1.42294 13.5195C0.64271 13.4897 0.0270348 12.8311 0.135334 12.0578C0.555929 9.05479 1.94319 6.2551 4.10674 4.09428C6.27028 1.93345 9.07171 0.549719 12.0753 0.132902C12.8487 0.0255755 13.5065 0.642079 13.5353 1.42235C13.5642 2.20262 12.9521 2.8494 12.1817 2.97646C9.89184 3.35413 7.76346 4.43838 6.10485 6.09491C4.44623 7.75144 3.35931 9.87845 2.97876 12.1678C2.85072 12.9381 2.20318 13.5493 1.42294 13.5195Z"
-          fill={segmentProgress >= 4 ? segmentFillColor : "#D2D1D4"}
+          fill={segmentProgress >= 4 ? accentColor : "#D2D1D4"}
         />
         {/* clock icon */}
         {segmentProgress <= 1 && (
@@ -130,6 +112,19 @@ export const WithdrawalProgressIcon = ({
               stroke="#9E9BA6"
               strokeWidth="1.25"
               strokeLinecap="round"
+            />
+          </>
+        )}
+        {/* finalized icon */}
+        {segmentProgress == 5 && (
+          <>
+            <path
+              d="M7 12.5L10.5 16L17 9.5"
+              stroke={accentColor ?? "#9E9BA6"}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              transform="translate(2 2.5)"
             />
           </>
         )}

--- a/src/components/icons/WithdrawalStatus.tsx
+++ b/src/components/icons/WithdrawalStatus.tsx
@@ -1,0 +1,108 @@
+import { StatusReturnType } from "../../types";
+import { statusStep } from "../../utils";
+
+export const WithdrawalStatusIcon = ({
+  status,
+  step,
+}: {
+  status: StatusReturnType;
+  step: number;
+}) => {
+  const currentStep = statusStep(status);
+
+  if (currentStep > step) {
+    return (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="24" height="24" rx="12" fill="#00B295" />
+        <path
+          d="M7 12.5L10.5 16L17 9.5"
+          stroke="#FEFEFE"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (step === 2) {
+    return (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M12.155 3.50965C12.0521 3.49678 11.9479 3.49678 11.845 3.50965L5.84496 4.25965C5.21942 4.33784 4.75 4.8696 4.75 5.5V14.409C4.75 16.2191 5.6825 17.9016 7.21751 18.8609L11.3375 21.4359C11.7428 21.6893 12.2572 21.6893 12.6625 21.4359L16.7825 18.8609C18.3175 17.9016 19.25 16.2191 19.25 14.409V5.5C19.25 4.8696 18.7806 4.33784 18.155 4.25965L12.155 3.50965ZM11.6589 2.02124C11.8854 1.99292 12.1146 1.99292 12.3411 2.02124L18.3411 2.77124C19.7173 2.94326 20.75 4.11311 20.75 5.5V14.409C20.75 16.7363 19.5511 18.8995 17.5775 20.1329L13.4575 22.7079C12.5658 23.2653 11.4342 23.2653 10.5425 22.7079L6.42251 20.1329C4.44893 18.8995 3.25 16.7363 3.25 14.409V5.5C3.25 4.11311 4.28273 2.94326 5.6589 2.77124L11.6589 2.02124Z"
+          fill="#9E9BA6"
+        />
+      </svg>
+    );
+  }
+
+  if (step === 3) {
+    return (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 7L20 12L15 17"
+          stroke="#9E9BA6"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M5 12L19 12"
+          stroke="#9E9BA6"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 12L12 17L17 12"
+        stroke="#9E9BA6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5 20L19 20"
+        stroke="#9E9BA6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12 4L12 16"
+        stroke="#9E9BA6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,4 @@
-export { WithdrawalStatusIcon } from "./WithdrawalStatus";
-export { WithdrawalProgressIcon } from "./WithdrawalProgress";
 export { ExternalLinkIcon } from "./ExternalLink";
+export { WalletIcon } from "./Wallet";
+export { WithdrawalProgressIcon } from "./WithdrawalProgress";
+export { WithdrawalStatusIcon } from "./WithdrawalStatus";

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,4 @@
+export { CloseIcon } from "./Close";
 export { ExternalLinkIcon } from "./ExternalLink";
 export { WalletIcon } from "./Wallet";
 export { WithdrawalProgressIcon } from "./WithdrawalProgress";

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,0 +1,3 @@
+export { WithdrawalStatusIcon } from "./WithdrawalStatus";
+export { WithdrawalProgressIcon } from "./WithdrawalProgress";
+export { ExternalLinkIcon } from "./ExternalLink";

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,5 @@ export type BridgeMode = "deposit" | "withdraw";
 export type StatusReturnType =
   | Awaited<ReturnType<typeof getWithdrawalStatus>>
   | "retrieving-status";
+
+export type TransactionType = "deposit" | "withdrawal" | "approval" | "unknown";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,14 @@
 import { format } from "dnum";
+import { getAddress, type WaitForTransactionReceiptReturnType } from "viem";
+
+import {
+  optimismPortal,
+  parentClient,
+  rollupChain,
+  rollupClient,
+  token,
+} from "./config";
+import type { StatusReturnType, TransactionType } from "./types";
 
 export const formatBalance = (balance: bigint, decimals: number) => {
   return format([balance, decimals], {
@@ -11,4 +21,49 @@ export const titleCase = (str: string): string => {
   return str.toLowerCase().replace(/\b\w+/g, (word) => {
     return word.charAt(0).toUpperCase() + word.slice(1);
   });
+};
+
+export const txType = (
+  transaction: WaitForTransactionReceiptReturnType
+): TransactionType => {
+  if (!transaction.to) return "unknown";
+  switch (getAddress(transaction.to)) {
+    case getAddress(rollupChain.contracts.l2ToL1MessagePasser.address):
+      return "withdrawal";
+    case getAddress(optimismPortal.address):
+      return "deposit";
+    case getAddress(token.address):
+      return "approval";
+    default:
+      return "unknown";
+  }
+};
+
+export const blockExplorerURL = (tx: WaitForTransactionReceiptReturnType) => {
+  const label = txType(tx);
+  switch (label) {
+    case "withdrawal":
+      return `${rollupClient.chain.blockExplorers.default.url}/tx/${tx.transactionHash}`;
+    default:
+      return `${parentClient.chain.blockExplorers.default.url}/tx/${tx.transactionHash}`;
+  }
+};
+
+export const statusStep = (status: StatusReturnType) => {
+  switch (status) {
+    case "retrieving-status":
+      return 0;
+    case "waiting-to-prove":
+      return 1;
+    case "ready-to-prove":
+      return 2;
+    case "waiting-to-finalize":
+      return 3;
+    case "ready-to-finalize":
+      return 4;
+    case "finalized":
+      return 5;
+    default:
+      return 0;
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.13.10":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
+  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.24.0":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
@@ -899,6 +906,148 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@radix-ui/primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz#71657b1b116de6c7a0b03242d7d43e01062c7300"
+  integrity sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-dismissable-layer@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz#3f98425b82b9068dfbab5db5fff3df6ebf48b9d4"
+  integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-focus-guards@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
+  integrity sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz#2ac45fce8c5bb33eb18419cdc1905ef4f1906525"
+  integrity sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-id@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"
+  integrity sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-portal@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.4.tgz#df4bfd353db3b1e84e639e9c63a5f2565fb00e15"
+  integrity sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-slot@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-use-callback-ref@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@rainbow-me/rainbowkit@^2.0.6":
   version "2.0.6"
@@ -1994,6 +2143,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.4.tgz#b78e383fdbc04d05762c78b4a25a501e736c4522"
+  integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
+  dependencies:
+    tslib "^2.0.0"
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -4320,13 +4476,24 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
-react-remove-scroll-bar@^2.3.4:
+react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz#3e585e9d163be84a010180b18721e851ac81a29c"
   integrity sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==
   dependencies:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
+
+react-remove-scroll@2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
 
 react-remove-scroll@2.5.7:
   version "2.5.7"


### PR DESCRIPTION
This adds a significant amount more detail to deposit and withdraw actions.

* clicking Approve still directly prompts for a transaction
* clicking Deposit presents a modal that shows details for the deposit
* clicking Withdraw still directly prompts for a transaction
* rows in the transaction table have been updated to account for Withdrawal Actions:
  * withdrawal status is displayed inline
  * when ready to prove or finalize, this opens a detail modal
  * detail modal displays a withdrawal progress modal with step-appropriate actions (see below)

![Screenshot 2024-05-29 at 10 30 47 AM](https://github.com/JoinOrigami/custom-gas-token-bridge/assets/2149/10c88609-648d-4a82-9c75-ef516fee2891)
