### PR TITLE
Support native currency (ETH) deposits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # An optional (but highly recommended) RPC URL for the L1 Chain
 VITE_L1_PUBLIC_RPC_URL="https://l1.example.com/rpc"
-# The address of the token on the parent chain that will be used as the gas token on the rollup - does not need to be on an L1
+# The address of the token on the parent chain that will be used as the gas token on the rollup - does not need to be on an "L1"
+# Alternatively, set to 0x0000000000000000000000000000000000000000 to use the bridge for native currency
 VITE_L1_CUSTOM_GAS_TOKEN_ADDRESS=0x01
 # The address of the "L1" (parent) contract that will be used to deposit/withdraw funds from the rollup
 VITE_L1_OPTIMISM_PORTAL_ADDRESS=0x02

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
   useTransactionStorage,
 } from "./hooks";
 import type { BridgeMode, WalletClient } from "./types";
-import { formatBalance } from "./utils";
+import { formatBalance, isCustomGasToken } from "./utils";
 import { walletActionsL1, walletActionsL2 } from "viem/op-stack";
 import { BridgeDirection } from "./components/BridgeDirection";
 import { OperationSummary } from "./components/OperationSummary";
@@ -91,7 +91,9 @@ function App() {
     setActionButtonDisabled(true);
     try {
       if (bridgeMode === "deposit" && isParentChain) {
-        if (isApproved) {
+        // if the chain does not use a custom gas token or if it does and the
+        // amount is approved, show the deposit modal
+        if (!isCustomGasToken() || isApproved) {
           setShowDepositModal(true);
         } else {
           await approvalFn(walletClient, submittedAmount);
@@ -109,7 +111,7 @@ function App() {
   const targetChain = bridgeMode === "deposit" ? rollupChain : parentChain;
 
   useEffect(() => {
-    setApproved(amount > 0n && allowance >= amount);
+    setApproved(!isCustomGasToken() || (amount > 0n && allowance >= amount));
     amount === 0n
       ? setActionButtonDisabled(true)
       : setActionButtonDisabled(false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
 import { format } from "dnum";
-import { getAddress, type WaitForTransactionReceiptReturnType } from "viem";
+import {
+  getAddress,
+  type WaitForTransactionReceiptReturnType,
+  zeroAddress,
+} from "viem";
 
 import {
   optimismPortal,
@@ -16,6 +20,9 @@ export const formatBalance = (balance: bigint, decimals: number) => {
     trailingZeros: false,
   });
 };
+
+export const isCustomGasToken = () =>
+  import.meta.env.VITE_L1_CUSTOM_GAS_TOKEN_ADDRESS !== zeroAddress;
 
 export const titleCase = (str: string): string => {
   return str.toLowerCase().replace(/\b\w+/g, (word) => {


### PR DESCRIPTION
This detects whether or not the bridge has been configured to use a custom gas token or if it's a standard ETH bridge. When `VITE_L1_CUSTOM_GAS_TOKEN_ADDRESS` is set to `address(0)`, the bridge will function as a standard OP bridge that uses Ether. Withdrawals work the same both ways, so only the deposit path was changed.