### PR TITLE
Store transactions for multiple wallets/bridges

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
   const [acknowledgementOne, setAcknowledgementOne] = useState(false);
   const [acknowledgementTwo, setAcknowledgementTwo] = useState(false);
   const [bridgeMode, setBridgeMode] = useState<BridgeMode>("deposit");
-  const { transactions, addTransaction } = useTransactionStorage();
+  const { transactionStore, addTransaction } = useTransactionStorage();
   const { isParentChain, isChildChain } = useIsParentChain();
 
   const logoUrl = import.meta.env.VITE_BRIDGE_LOGO_URL;
@@ -103,19 +103,19 @@ function App() {
   const approvalFn = async (walletClient: WalletClient, amount: bigint) => {
     const l1WalletClient = walletClient.extend(walletActionsL1());
     const transaction = await approvalTransaction(l1WalletClient, amount);
-    addTransaction(transaction);
+    addTransaction(walletClient, transaction);
   };
 
   const depositFn = async (walletClient: WalletClient, amount: bigint) => {
     const l1WalletClient = walletClient.extend(walletActionsL1());
     const transaction = await depositTransaction(l1WalletClient, amount);
-    addTransaction(transaction);
+    addTransaction(walletClient, transaction);
   };
 
   const withdrawFn = async (walletClient: WalletClient, amount: bigint) => {
     const l2WalletClient = walletClient.extend(walletActionsL2());
     const transaction = await initiateWithdrawal(amount, l2WalletClient);
-    addTransaction(transaction);
+    addTransaction(walletClient, transaction);
   };
 
   const onSubmit: SubmitHandler<Inputs> = async ({ amount: etherAmount }) => {
@@ -248,7 +248,7 @@ function App() {
                   />
                 </div>
                 <div className="w-full m-auto max-w-screen-body flex flex-col gap-4 px-2 pt-6 lg:pt-0">
-                  <Transactions transactions={transactions} />
+                  <Transactions transactionStore={transactionStore} />
                 </div>
               </div>
             </div>

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -1,5 +1,8 @@
-import { TransactionReceipt } from "viem";
+import { useWalletClient } from "wagmi";
+
 import { TransactionRow } from "./TransactionRow";
+import type { TransactionStore } from "../types";
+import { getTransactions } from "../utils";
 
 const ThCell = ({ children }: { children: React.ReactElement | string }) => {
   return (
@@ -13,13 +16,17 @@ const ThCell = ({ children }: { children: React.ReactElement | string }) => {
 };
 
 export const Transactions = ({
-  transactions,
+  transactionStore,
 }: {
-  transactions: TransactionReceipt[];
+  transactionStore: TransactionStore;
 }) => {
-  if (transactions.length === 0) {
-    return null;
-  }
+  const { data: walletClient } = useWalletClient();
+
+  const address = walletClient?.account?.address;
+  if (!address) return;
+
+  const transactions = getTransactions(transactionStore, address);
+  if (transactions.length === 0) return;
 
   return (
     <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { createPublicClient, Account, Chain } from "viem";
+import { createPublicClient } from "viem";
+import type { Account, Address, Chain } from "viem";
 import { getWithdrawalStatus } from "viem/op-stack";
 import {
   PublicActionsL1,
@@ -7,6 +8,7 @@ import {
   WalletActionsL2,
 } from "viem/op-stack";
 import { UseWalletClientReturnType } from "wagmi";
+import type { WaitForTransactionReceiptReturnType } from "viem";
 import { rollupChain } from "./config";
 
 type MakeKeyRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
@@ -35,6 +37,15 @@ export type L2WalletClient = WalletClient &
   WalletActionsL2<ChainWithExplorer, Account>;
 
 export type BridgeMode = "deposit" | "withdraw";
+
+// A BridgeId is the combination of the parent chain id and the rollup chain id
+export type BridgeId = `${number}:${number}`;
+
+export type TransactionStore = {
+  [address: Address]: {
+    [bridgeId: BridgeId]: WaitForTransactionReceiptReturnType[];
+  };
+};
 
 export type StatusReturnType =
   | Awaited<ReturnType<typeof getWithdrawalStatus>>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,16 +3,23 @@ import {
   getAddress,
   type WaitForTransactionReceiptReturnType,
   zeroAddress,
+  Address,
 } from "viem";
 
 import {
   optimismPortal,
+  parentChain,
   parentClient,
   rollupChain,
   rollupClient,
   token,
 } from "./config";
-import type { StatusReturnType, TransactionType } from "./types";
+import type {
+  BridgeId,
+  StatusReturnType,
+  TransactionStore,
+  TransactionType,
+} from "./types";
 
 export const formatBalance = (balance: bigint, decimals: number) => {
   return format([balance, decimals], {
@@ -71,4 +78,16 @@ export const statusStep = (status: StatusReturnType) => {
     default:
       return 0;
   }
+};
+
+export const getBridgeId = (): BridgeId => {
+  return `${parentChain.id}:${rollupChain.id}`;
+};
+
+export const getTransactions = (
+  transactionStore: TransactionStore,
+  address: Address
+) => {
+  const bridgeId = getBridgeId();
+  return (transactionStore[address] ?? {})[bridgeId] ?? [];
 };


### PR DESCRIPTION
Support storing transactions regardless of wallet (and as a convenience for development; bridge) switching using the data structure described in this type:

```typescript
export type TransactionStore = {
  [address: Address]: {
    [bridgeId: BridgeId]: WaitForTransactionReceiptReturnType[];
  };
};
```